### PR TITLE
Implemented Test 8: Prevent deleting non-existent counter

### DIFF
--- a/tdd_lab/src/counter.py
+++ b/tdd_lab/src/counter.py
@@ -59,8 +59,8 @@ def increment_counter(name):
   return jsonify({name: COUNTERS[name]}), status.HTTP_200_OK
 
 @app.route('/counters/<name>', methods=['DELETE'])
-def destory_counter(name):
-  """Destroy a counter"""
+def delete_counter(name):
+  """Delete a counter"""
   if not counter_exists(name):
       return jsonify({"error": f"Counter {name} does not exist."}), status.HTTP_409_CONFLICT
   

--- a/tdd_lab/src/counter.py
+++ b/tdd_lab/src/counter.py
@@ -28,3 +28,41 @@ def increment_counter(name):
   COUNTERS[name] += 1
   return jsonify({name: COUNTERS[name]}), status.HTTP_200_OK
 
+"""
+Counter API Implementation
+"""
+from flask import Flask
+from flask import jsonify
+from src import status 
+app = Flask(__name__)
+
+COUNTERS = {}
+
+@app.route('/counters/<name>', methods=['POST'])
+def create_counter(name):
+  """Create a counter"""
+  if counter_exists(name):
+      return jsonify({"error": f"Counter {name} already exists"}), status.HTTP_409_CONFLICT
+  COUNTERS[name] = 0
+  return jsonify({name: COUNTERS[name]}), status.HTTP_201_CREATED
+
+def counter_exists(name):
+    """Check if counter exists"""
+    return name in COUNTERS
+
+@app.route('/counters/<name>', methods=['PUT'])
+def increment_counter(name):
+  """Create a counter"""
+  if not counter_exists(name):
+      return jsonify({"error": f"Counter {name} does not exist."}), status.HTTP_409_CONFLICT
+  COUNTERS[name] += 1
+  return jsonify({name: COUNTERS[name]}), status.HTTP_200_OK
+
+@app.route('/counters/<name>', methods=['DELETE'])
+def destory_counter(name):
+  """Destroy a counter"""
+  if not counter_exists(name):
+      return jsonify({"error": f"Counter {name} does not exist."}), status.HTTP_409_CONFLICT
+  
+  del COUNTERS[name]
+  return jsonify({"message": f"Counter {name} has been deleted."}), status.HTTP_200_OK

--- a/tdd_lab/tests/test_counter.py
+++ b/tdd_lab/tests/test_counter.py
@@ -36,7 +36,7 @@ class TestCounterEndpoints:
 
     # Jesse Ortega
     def test_prevent_deletion_non_existent_counter(self, client):
-        # This test should not delete a counter that doesn't exist
+        # This test should attempt to delete a counter that doesn't exist
         counter = client.delete('/counters/non_existent_counter')
         # Assert that we get a 409 error from the DELETE request
         assert counter.status_code == status.HTTP_409_CONFLICT

--- a/tdd_lab/tests/test_counter.py
+++ b/tdd_lab/tests/test_counter.py
@@ -33,3 +33,10 @@ class TestCounterEndpoints:
         counter = client.put('/counters/non_existent_counter')
         # Assert that we get a 409 error from the PUT request
         assert counter.status_code == status.HTTP_409_CONFLICT
+
+    # Jesse Ortega
+    def test_prevent_deletion_non_existent_counter(self, client):
+        # This test should not delete a counter that doesn't exist
+        counter = client.delete('/counters/non_existent_counter')
+        # Assert that we get a 409 error from the DELETE request
+        assert counter.status_code == status.HTTP_409_CONFLICT


### PR DESCRIPTION
Did as title states. Within tests/test_counter, test_prevent_deletion_non_existent_counter(self, client) attempts to delete a non-existent counter and expects to receive a conflict status code. Within src/counter.py, delete_counter(name) return a conflict status if the counter requested to be deleted does not exist; otherwise, it deletes the counter and responds with an 'OK' status.