### PR TITLE
Simplified 'verifyStudentUserExistsInMetaData' Method and Closes #86

### DIFF
--- a/gen_ai/task2.1/DanielLevy_refactor_code.py
+++ b/gen_ai/task2.1/DanielLevy_refactor_code.py
@@ -1,0 +1,12 @@
+# ChatGPT Code Refactoring
+import os
+import pandas as pd
+
+def extractMetaDataFromCSV(self):
+    csv_file = next((f for f in os.listdir(self.dirName) if f.endswith('.csv')), None)
+
+    if csv_file:
+        self.metaData = pd.read_csv(os.path.join(self.dirName, csv_file))
+    else:
+        print("No .csv file containing student metadata was found.")
+        exit(1)

--- a/gen_ai/task2.2/DanielLevy_docstring_update.py
+++ b/gen_ai/task2.2/DanielLevy_docstring_update.py
@@ -1,0 +1,18 @@
+# ChatGPT Documentation Suggestion
+def checkIfStudentFileExists(self, fileName):
+    """
+    Checks if a student submission file exists in the ZIP directory.
+
+    This method takes a file name containing a student name and an ID, extracts
+    both values, and verifies whether the file exists in the specified ZIP directory.
+    If the file is missing, an error message is logged.
+
+    Args:
+        fileName (str): The name of the file, expected to be in the format
+                        "{submission_id}-{student_name}".
+
+    Returns:
+        tuple: A tuple containing:
+            - subID (int): The extracted submission ID.
+            - studentName (str): The extracted student name.
+    """

--- a/gen_ai/task2.3/DanielLevy_understand_code.py
+++ b/gen_ai/task2.3/DanielLevy_understand_code.py
@@ -1,0 +1,17 @@
+# ChatGPT improvement
+def verifyStudentUserExistsInMetaData(self):
+    for key, value in self.users.items():
+        subID, studentName = self.checkIfStudentFileExists(key)
+
+        entry = self.metaData.loc[self.metaData['Id'] == value]
+
+        if entry.empty:
+            self.addError(f"Error! No metadata for user ID {value} was found.", 'meta')
+            continue
+
+        if entry.shape[0] > 1:
+            self.addError(f"Error! User ID {value} has more than one entry.", 'meta')
+            continue
+
+        if entry.iloc[0, 2] != studentName:
+            self.addError(f"Error! User ID {value} does not have a matching name.", 'meta')


### PR DESCRIPTION
This PR fixes #86. I used ChatGPT to help improve and simplify the method 'verifyStudentUserExistsInMetaData' in the data ingestion phase of PRISM, and the code is now much easier to maintain. This code is now ready to be pushed into the master branch.

ChatGPT Suggestion Link: https://chatgpt.com/share/67c213bc-265c-8001-8d66-8b550cc98394